### PR TITLE
update lib update-psr-http-message-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     "symfony/http-kernel": "^4.4",
     "symfony/property-access": " ^4.4",
     "symfony/property-info": " ^4.4",
-    "symfony/psr-http-message-bridge": "^1.0",
+    "symfony/psr-http-message-bridge": "^1.2 || ^2.1.2",
     "symfony/serializer": " ^4.4",
     "symfony/yaml": " ^4.4"
   },


### PR DESCRIPTION
Why ^1.2 || ^2.1.2 : 

If i put only 2.1.2, we can not update api-tester on SdzV4 because we will have error `it's required 1.2 psr-http-message-bridge`  

NO BC 🎉 
Lib releases : https://github.com/symfony/psr-http-message-bridge/releases