### PR TITLE
fix case where required parameters is null

### DIFF
--- a/src/Preparator/Error400MissingRequiredFieldsPreparator.php
+++ b/src/Preparator/Error400MissingRequiredFieldsPreparator.php
@@ -60,11 +60,12 @@ final class Error400MissingRequiredFieldsPreparator extends Error400Preparator
     {
         $testCases = [];
 
+        /** @var string[]|null $requiredFields */
         $requiredFields = $body->getSchema()
             ->required;
         $bodyExample = $body->getExample();
         foreach ($bodyExample as $name => $value) {
-            if (!\in_array($name, $requiredFields, true)) {
+            if (null === $requiredFields || !\in_array($name, $requiredFields, true)) {
                 continue;
             }
             $testCases[] = $this->createTestCase(


### PR DESCRIPTION
There was a bug when no required field was passed. Contrary to what the php-openapi doc says:

in `vendor/cebe/php-openapi/src/spec/Schema.php`
> * @property string[] $required list of required properties

this property can be null.