### PR TITLE
Adding Tunable SuccessStatusCode either 200 or 201 for Example Prepator

### DIFF
--- a/src/Definition/Example/OperationExample.php
+++ b/src/Definition/Example/OperationExample.php
@@ -52,12 +52,13 @@ final class OperationExample
 
     public function __construct(
         private string $name,
-        Operation $parent = null
+        Operation $parent = null,
+        int $statusCode = null
     ) {
         if ($parent !== null) {
             $this->parent = $parent;
         }
-        $this->response = new ResponseExample();
+        $this->response = new ResponseExample($statusCode !== null ? "{$statusCode}" : null);
         $this->deepCopy = new DeepCopy();
         $this->deepCopy->addTypeFilter(
             new ShallowCopyFilter(),


### PR DESCRIPTION
Examples from the doc always expect status code 200.

We now check the 200 and 201 success codes from the possibles responses, and check against the success code defined in the openapi file.

Example : 
the `/student-applications/{studentApplicationId}/submit ` returns a 201.

But it was failing because api-tester was expecting a 200 on success


Fixes :
```
examples - oc_api_student_application_post - properties
examples - oc_api_disqualify_student_application_post - properties
examples - oc_api_churn_student_application_post - properties
examples - oc_api_admit_student_application_post - properties
examples - oc_api_submit_student_application_post - properties
```

[JIRA](https://simple-it.atlassian.net/browse/OC-50688)