### PR TITLE
feat(api tester): use set examples to build 404 request body

### DIFF
--- a/src/Definition/Example/OperationExample.php
+++ b/src/Definition/Example/OperationExample.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace APITester\Definition\Example;
 
+use APITester\Definition\Body;
 use APITester\Definition\Collection\Tokens;
 use APITester\Definition\Operation;
 use APITester\Definition\Parameter;
@@ -335,7 +336,7 @@ final class OperationExample
             return BodyExample::create($requestBody->getRandomContent());
         }
 
-        if ($this->autoComplete) {
+        if ($this->autoComplete && !$this->isExampleProvidedAtRootLevel($requestBody)) {
             $randomBody = BodyExample::create($requestBody->getRandomContent());
             if ($this->body !== null) {
                 $this->body->setContent(array_merge($randomBody->getContent(), $this->body->getContent()));
@@ -594,5 +595,11 @@ final class OperationExample
         }
 
         return [];
+    }
+
+    private function isExampleProvidedAtRootLevel(Body $requestBody): bool
+    {
+        return $requestBody->getSchema()
+            ->example !== null;
     }
 }

--- a/src/Definition/Example/OperationExample.php
+++ b/src/Definition/Example/OperationExample.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace APITester\Definition\Example;
 
-use APITester\Definition\Body;
 use APITester\Definition\Collection\Tokens;
 use APITester\Definition\Operation;
 use APITester\Definition\Parameter;
@@ -55,6 +54,7 @@ final class OperationExample
         private string $name,
         ?Operation $parent = null,
         ?int $statusCode = null,
+        private bool $isRootLevelExample = false
     ) {
         if ($parent !== null) {
             $this->parent = $parent;
@@ -336,7 +336,7 @@ final class OperationExample
             return BodyExample::create($requestBody->getRandomContent());
         }
 
-        if ($this->autoComplete && !$this->isExampleProvidedAtRootLevel($requestBody)) {
+        if ($this->autoComplete && !$this->isRootLevelExample) {
             $randomBody = BodyExample::create($requestBody->getRandomContent());
             if ($this->body !== null) {
                 $this->body->setContent(array_merge($randomBody->getContent(), $this->body->getContent()));
@@ -529,6 +529,11 @@ final class OperationExample
         ;
     }
 
+    public function setIsRootLevelExample(bool $isRootLevelExample): void
+    {
+        $this->isRootLevelExample = $isRootLevelExample;
+    }
+
     private function getParametersProp(string $type): string
     {
         if ($type === 'path') {
@@ -595,11 +600,5 @@ final class OperationExample
         }
 
         return [];
-    }
-
-    private function isExampleProvidedAtRootLevel(Body $requestBody): bool
-    {
-        return $requestBody->getSchema()
-            ->example !== null;
     }
 }

--- a/src/Definition/Loader/OpenApiDefinitionLoader.php
+++ b/src/Definition/Loader/OpenApiDefinitionLoader.php
@@ -447,21 +447,32 @@ final class OpenApiDefinitionLoader implements DefinitionLoader
         }
 
         if ($operation->requestBody instanceof RequestBody) {
+            $requestBodyExampleIsProvided = false;
             foreach ($operation->requestBody->content as $mediaType) {
                 /** @var Example $example */
                 foreach ($mediaType->examples ?? [] as $name => $example) {
                     $operationExample = $this->getExample($name, $examples);
-                    $operationExample->setBody(BodyExample::create((array) $example->value));
+                    $operationExample->setBody(BodyExample::create((array) $example->value))->setIsRootLevelExample(
+                        true
+                    );
+                    $requestBodyExampleIsProvided = true;
                 }
                 if ($mediaType->example !== null) {
                     $operationExample = $this->getExample('default', $examples);
-                    $operationExample->setBody(BodyExample::create((array) $mediaType->example));
+                    $operationExample->setBody(BodyExample::create((array) $mediaType->example))->setIsRootLevelExample(
+                        true
+                    );
+                    $requestBodyExampleIsProvided = true;
                 }
                 if ($mediaType->schema instanceof Schema) {
                     if ($mediaType->schema->example !== null) {
                         $operationExample = $this->getExample('default', $examples);
-                        $operationExample->setBody(BodyExample::create((array) $mediaType->schema->example));
-                    } else {
+                        $operationExample->setBody(BodyExample::create((array) $mediaType->schema->example))
+                            ->setIsRootLevelExample(true)
+                        ;
+                        $requestBodyExampleIsProvided = true;
+                    }
+                    if ($requestBodyExampleIsProvided === false) {
                         try {
                             $example = (array) $this->extractDeepExamples(
                                 $mediaType->schema,
@@ -597,12 +608,12 @@ final class OpenApiDefinitionLoader implements DefinitionLoader
             return null;
         }
 
-        if ($this->exampleIsSetAtRootLevel($schema)) {
-            return $schema->example;
-        }
-
         if (isset($schema->type)) {
             if ($schema->type === 'array' && $schema->items instanceof Schema) {
+                if ($schema->example !== null) {
+                    return $schema->example;
+                }
+
                 return [
                     $this->extractDeepExamples($schema->items, false, $path),
                 ];
@@ -633,6 +644,10 @@ final class OpenApiDefinitionLoader implements DefinitionLoader
             }
         }
 
+        if (isset($schema->example)) {
+            return $schema->example;
+        }
+
         if (isset($schema->default)) {
             return $schema->default;
         }
@@ -644,10 +659,5 @@ final class OpenApiDefinitionLoader implements DefinitionLoader
         throw new InvalidExampleException(
             'Could not extract example for ' . $path
         );
-    }
-
-    private function exampleIsSetAtRootLevel(Schema $schema): bool
-    {
-        return isset($schema->example);
     }
 }

--- a/src/Definition/Loader/OpenApiDefinitionLoader.php
+++ b/src/Definition/Loader/OpenApiDefinitionLoader.php
@@ -597,12 +597,12 @@ final class OpenApiDefinitionLoader implements DefinitionLoader
             return null;
         }
 
+        if ($this->exampleIsSetAtRootLevel($schema)) {
+            return $schema->example;
+        }
+
         if (isset($schema->type)) {
             if ($schema->type === 'array' && $schema->items instanceof Schema) {
-                if ($schema->example !== null) {
-                    return $schema->example;
-                }
-
                 return [
                     $this->extractDeepExamples($schema->items, false, $path),
                 ];
@@ -633,10 +633,6 @@ final class OpenApiDefinitionLoader implements DefinitionLoader
             }
         }
 
-        if (isset($schema->example)) {
-            return $schema->example;
-        }
-
         if (isset($schema->default)) {
             return $schema->default;
         }
@@ -648,5 +644,10 @@ final class OpenApiDefinitionLoader implements DefinitionLoader
         throw new InvalidExampleException(
             'Could not extract example for ' . $path
         );
+    }
+
+    private function exampleIsSetAtRootLevel(Schema $schema): bool
+    {
+        return isset($schema->example);
     }
 }

--- a/src/Preparator/Error404Preparator.php
+++ b/src/Preparator/Error404Preparator.php
@@ -43,11 +43,7 @@ final class Error404Preparator extends TestCasesPreparator
         $base = $operation->getExample();
 
         $example = OperationExample::create('RandomPath', $operation)
-            // Disable autocompletion to avoid injecting random (potentially
-            // invalid) data into the request.
             ->setAutoComplete(false)
-            // Only the path is randomized so the request targets a resource
-            // that does not exist, which is what should trigger the 404.
             ->setPathParameters($operation->getPathParameters()->getRandomExamples())
             ->setQueryParameters($base->getQueryParameters())
             ->setHeaders($base->getHeaders())

--- a/src/Preparator/Error404Preparator.php
+++ b/src/Preparator/Error404Preparator.php
@@ -27,45 +27,37 @@ final class Error404Preparator extends TestCasesPreparator
                 /** @var DefinitionResponse $response */
                 return $this->prepareTestCase($response);
             })
-            ->flatten()
         ;
     }
 
-    /**
-     * @return array<TestCase>
-     */
-    private function prepareTestCase(DefinitionResponse $response): array
+    private function prepareTestCase(DefinitionResponse $response): TestCase
     {
         $operation = $response->getParent();
 
-        $testcases = [];
+        $base = $operation->getExample();
 
-        if ($operation->getRequestBodies()->count() === 0) {
-            $testcases[] = $this->buildTestCase(
-                OperationExample::create('RandomPath', $operation)
-                    ->setForceRandom()
-                    ->setResponse(
-                        ResponseExample::create()
-                            ->setStatusCode($this->config->response->getStatusCode() ?? '404')
-                            ->setHeaders($this->config->response->headers ?? [])
-                            ->setContent($this->config->response->body ?? $response->getDescription())
-                    )
-            );
+        $example = OperationExample::create('RandomPath', $operation)
+            // Disable autocompletion to avoid injecting random (potentially
+            // invalid) data into the request.
+            ->setAutoComplete(false)
+            // Only the path is randomized so the request targets a resource
+            // that does not exist, which is what should trigger the 404.
+            ->setPathParameters($operation->getPathParameters()->getRandomExamples())
+            ->setQueryParameters($base->getQueryParameters())
+            ->setHeaders($base->getHeaders())
+            ->setResponse(
+                ResponseExample::create()
+                    ->setStatusCode($this->config->response->getStatusCode() ?? '404')
+                    ->setHeaders($this->config->response->headers ?? [])
+                    ->setContent($this->config->response->body ?? $response->getDescription())
+            )
+        ;
+
+        $baseBody = $base->getBody();
+        if ($baseBody !== null) {
+            $example->setBodyContent($baseBody->getContent());
         }
 
-        foreach ($operation->getRequestBodies() as $ignored) {
-            $testcases[] = $this->buildTestCase(
-                OperationExample::create('RandomPath', $operation)
-                    ->setForceRandom()
-                    ->setResponse(
-                        ResponseExample::create()
-                            ->setStatusCode($this->config->response->getStatusCode() ?? '404')
-                            ->setHeaders($this->config->response->headers ?? [])
-                            ->setContent($this->config->response->body ?? $response->getDescription())
-                    )
-            );
-        }
-
-        return $testcases;
+        return $this->buildTestCase($example);
     }
 }

--- a/src/Preparator/Error404Preparator.php
+++ b/src/Preparator/Error404Preparator.php
@@ -27,12 +27,18 @@ final class Error404Preparator extends TestCasesPreparator
                 /** @var DefinitionResponse $response */
                 return $this->prepareTestCase($response);
             })
+            ->filter(static fn (?TestCase $testCase) => $testCase !== null)
+            ->values()
         ;
     }
 
-    private function prepareTestCase(DefinitionResponse $response): TestCase
+    private function prepareTestCase(DefinitionResponse $response): ?TestCase
     {
         $operation = $response->getParent();
+
+        if ($operation->getPathParameters()->count() === 0) {
+            return null;
+        }
 
         $base = $operation->getExample();
 

--- a/tests/Definition/Loader/OpenApiDefinitionLoaderTest.php
+++ b/tests/Definition/Loader/OpenApiDefinitionLoaderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace APITester\Tests\Definition\Loader;
+
+use APITester\Definition\Loader\OpenApiDefinitionLoader;
+use APITester\Tests\Fixtures\FixturesLocation;
+use PHPUnit\Framework\TestCase;
+
+final class OpenApiDefinitionLoaderTest extends TestCase
+{
+    public function testSchemaLevelArrayExampleTakesPrecedence(): void
+    {
+        $api = (new OpenApiDefinitionLoader())->load(
+            FixturesLocation::OPEN_API_WITH_SCHEMA_EXAMPLE
+        );
+
+        $operation = $api->getOperations()
+            ->first(
+                static fn ($op) => $op->getId() === 'createArrayBody'
+            );
+        $body = $operation->getExample()
+            ->getBody();
+
+        self::assertNotNull($body);
+        self::assertSame(
+            [
+                [
+                    'id' => 5656,
+                    'evaluationCriteria' => 'KDKKE Ipsum',
+                ],
+            ],
+            $body->getContent()
+        );
+    }
+
+    public function testSchemaLevelObjectExampleTakesPrecedence(): void
+    {
+        $api = (new OpenApiDefinitionLoader())->load(
+            FixturesLocation::OPEN_API_WITH_SCHEMA_EXAMPLE
+        );
+
+        $operation = $api->getOperations()
+            ->first(
+                static fn ($op) => $op->getId() === 'createObjectBody'
+            );
+        $body = $operation->getExample()
+            ->getBody();
+
+        self::assertNotNull($body);
+        self::assertSame(
+            [
+                'id' => 5656,
+                'evaluationCriteria' => 'KDKKE Ipsum',
+            ],
+            $body->getContent()
+        );
+    }
+}

--- a/tests/Definition/Loader/OpenApiDefinitionLoaderTest.php
+++ b/tests/Definition/Loader/OpenApiDefinitionLoaderTest.php
@@ -19,9 +19,11 @@ final class OpenApiDefinitionLoaderTest extends TestCase
         $operation = $api->getOperations()
             ->first(
                 static fn ($op) => $op->getId() === 'createArrayBody'
-            );
+            )
+        ;
         $body = $operation->getExample()
-            ->getBody();
+            ->getBody()
+        ;
 
         self::assertNotNull($body);
         self::assertSame(
@@ -35,6 +37,64 @@ final class OpenApiDefinitionLoaderTest extends TestCase
         );
     }
 
+    public function testMediaTypeLevelExample(): void
+    {
+        $api = (new OpenApiDefinitionLoader())->load(
+            FixturesLocation::OPEN_API_WITH_SCHEMA_EXAMPLE
+        );
+
+        $operation = $api->getOperations()
+            ->first(
+                static fn ($op) => $op->getId() === 'createMediaTypeExample'
+            )
+        ;
+        $body = $operation->getExample()
+            ->getBody()
+        ;
+
+        self::assertNotNull($body);
+        self::assertSame(
+            [
+                'id' => 111,
+                'evaluationCriteria' => 'strict evaluation',
+            ],
+            $body->getContent()
+        );
+    }
+
+    public function testMediaTypeLevelExamples(): void
+    {
+        $api = (new OpenApiDefinitionLoader())->load(
+            FixturesLocation::OPEN_API_WITH_SCHEMA_EXAMPLE
+        );
+
+        $operation = $api->getOperations()
+            ->first(
+                static fn ($op) => $op->getId() === 'createMediaTypeExamples'
+            )
+        ;
+        $body = $operation->getExamples();
+        self::assertCount(3, $body);
+
+        self::assertSame(
+            [
+                'id' => 10,
+                'evaluationCriteria' => 'Jessica Smith',
+            ],
+            $operation->getExample('criteria')
+                ->getBody()
+                ->getContent()
+        );
+        self::assertSame(
+            [
+                'id' => 11,
+            ],
+            $operation->getExample('noCriteria')
+                ->getBody()
+                ->getContent()
+        );
+    }
+
     public function testSchemaLevelObjectExampleTakesPrecedence(): void
     {
         $api = (new OpenApiDefinitionLoader())->load(
@@ -44,9 +104,11 @@ final class OpenApiDefinitionLoaderTest extends TestCase
         $operation = $api->getOperations()
             ->first(
                 static fn ($op) => $op->getId() === 'createObjectBody'
-            );
+            )
+        ;
         $body = $operation->getExample()
-            ->getBody();
+            ->getBody()
+        ;
 
         self::assertNotNull($body);
         self::assertSame(
@@ -56,5 +118,47 @@ final class OpenApiDefinitionLoaderTest extends TestCase
             ],
             $body->getContent()
         );
+    }
+
+    public function testRootLevelExampleIsNotAutoCompletedWithRandomData(): void
+    {
+        $api = (new OpenApiDefinitionLoader())->load(
+            FixturesLocation::OPEN_API_WITH_SCHEMA_EXAMPLE
+        );
+
+        $operation = $api->getOperations()
+            ->first(
+                static fn ($op) => $op->getId() === 'createMediaTypeExamples'
+            )
+        ;
+
+        // The "noCriteria" example only defines "id"; being a root level example it
+        // must be used verbatim and not be merged with random schema based values.
+        $body = $operation->getExample('noCriteria')
+            ->getBody()
+        ;
+
+        self::assertNotNull($body);
+        self::assertSame(
+            [
+                'id' => 11,
+            ],
+            $body->getContent()
+        );
+    }
+
+    public function testOptionalRequestBodyWithoutExampleProducesNoExamples(): void
+    {
+        $api = (new OpenApiDefinitionLoader())->load(
+            FixturesLocation::OPEN_API_WITH_SCHEMA_EXAMPLE
+        );
+
+        $operation = $api->getOperations()
+            ->first(
+                static fn ($op) => $op->getId() === 'createOptionalBodyWithoutExample'
+            )
+        ;
+
+        self::assertSame(0, $operation->getExamples()->count());
     }
 }

--- a/tests/Fixtures/FixturesLocation.php
+++ b/tests/Fixtures/FixturesLocation.php
@@ -19,4 +19,6 @@ final class FixturesLocation
     public const CONFIG_EXAMPLES_EXTENSION = __DIR__ . '/Examples/petstore/examples.new.yml';
 
     public const OPEN_API_WITH_EXAMPLES = __DIR__ . '/OpenAPI/openapi-with-examples.yaml';
+
+    public const OPEN_API_WITH_SCHEMA_EXAMPLE = __DIR__ . '/OpenAPI/openapi-with-schema-example.yaml';
 }

--- a/tests/Fixtures/OpenAPI/openapi-with-schema-example.yaml
+++ b/tests/Fixtures/OpenAPI/openapi-with-schema-example.yaml
@@ -1,0 +1,62 @@
+openapi: "3.0.0"
+info:
+    version: 1.0.0
+    title: Schema level example
+    license:
+        name: MIT
+servers:
+    -   url: http://example.test/v1
+paths:
+    /array-body:
+        post:
+            summary: Array body with a schema level example
+            operationId: createArrayBody
+            requestBody:
+                description: ''
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            example:
+                                -   id: 5656
+                                    evaluationCriteria: 'KDKKE Ipsum'
+                            items:
+                                type: object
+                                properties:
+                                    id:
+                                        nullable: false
+                                        type: integer
+                                        example: 12345
+                                    evaluationCriteria:
+                                        type: string
+                                        nullable: true
+                                        example: 'Lorem Ipsum'
+            responses:
+                '201':
+                    description: created
+    /object-body:
+        post:
+            summary: Object body with a schema level example
+            operationId: createObjectBody
+            requestBody:
+                description: ''
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            example:
+                                id: 5656
+                                evaluationCriteria: 'KDKKE Ipsum'
+                            properties:
+                                id:
+                                    nullable: false
+                                    type: integer
+                                    example: 12345
+                                evaluationCriteria:
+                                    type: string
+                                    nullable: true
+                                    example: 'Lorem Ipsum'
+            responses:
+                '201':
+                    description: created
+

--- a/tests/Fixtures/OpenAPI/openapi-with-schema-example.yaml
+++ b/tests/Fixtures/OpenAPI/openapi-with-schema-example.yaml
@@ -34,6 +34,65 @@ paths:
             responses:
                 '201':
                     description: created
+    /media-type-array-examples:
+        post:
+            summary: Array body with mediatype level examples
+            operationId: createMediaTypeExamples
+            requestBody:
+                description: ''
+                content:
+                    application/json:
+                        examples:
+                            criteria:
+                                value:
+                                    id: 10
+                                    evaluationCriteria: Jessica Smith
+                            noCriteria:
+                                value:
+                                    id: 11
+                        schema:
+                            type: array
+                            items:
+                                type: object
+                                properties:
+                                    id:
+                                        nullable: false
+                                        type: integer
+                                        example: 12345
+                                    evaluationCriteria:
+                                        type: string
+                                        nullable: true
+                                        example: 'Lorem Ipsum'
+            responses:
+                '201':
+                    description: created
+    /media-type-example:
+        post:
+            summary: Array body with a mediatype level example
+            operationId: createMediaTypeExample
+            requestBody:
+                description: ''
+                content:
+                    application/json:
+                        example:
+                            id: 111
+                            evaluationCriteria: strict evaluation
+                        schema:
+                            type: array
+                            items:
+                                type: object
+                                properties:
+                                    id:
+                                        nullable: false
+                                        type: integer
+                                        example: 12345
+                                    evaluationCriteria:
+                                        type: string
+                                        nullable: true
+                                        example: 'Lorem Ipsum'
+            responses:
+                '201':
+                    description: created
     /object-body:
         post:
             summary: Object body with a schema level example
@@ -59,4 +118,24 @@ paths:
             responses:
                 '201':
                     description: created
-
+    /optional-body-without-example:
+        post:
+            summary: Optional request body without any example
+            operationId: createOptionalBodyWithoutExample
+            requestBody:
+                description: ''
+                required: false
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                id:
+                                    nullable: false
+                                    type: integer
+                                evaluationCriteria:
+                                    type: string
+                                    nullable: true
+            responses:
+                '201':
+                    description: created

--- a/tests/Preparator/Error404PreparatorTest.php
+++ b/tests/Preparator/Error404PreparatorTest.php
@@ -145,7 +145,7 @@ final class Error404PreparatorTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        yield 'without param' => [
+        yield 'without param test is not created' => [
             Api::create()
                 ->addOperation(
                     Operation::create('postTest', '/test', 'POST')
@@ -169,20 +169,7 @@ final class Error404PreparatorTest extends \PHPUnit\Framework\TestCase
                         )
                 ),
             [
-                new TestCase(
-                    Error404Preparator::getName() . ' - postTest - RandomPath',
-                    OperationExample::create('test1')
-                        ->setPath('/test')
-                        ->setMethod('POST')
-                        ->setBodyContent(
-                            [
-                                'name' => 'toto',
-                            ]
-                        )
-                        ->setResponse(
-                            ResponseExample::create('404', 'description test')
-                        ),
-                ),
+
             ],
         ];
     }

--- a/tests/Preparator/Error404PreparatorTest.php
+++ b/tests/Preparator/Error404PreparatorTest.php
@@ -6,6 +6,7 @@ namespace APITester\Tests\Preparator;
 
 use APITester\Definition\Api;
 use APITester\Definition\Body;
+use APITester\Definition\Example\BodyExample;
 use APITester\Definition\Example\OperationExample;
 use APITester\Definition\Example\ResponseExample;
 use APITester\Definition\Operation;
@@ -31,6 +32,81 @@ final class Error404PreparatorTest extends \PHPUnit\Framework\TestCase
             $expected,
             $preparator->doPrepare($api->getOperations()),
             ['parent', 'body']
+        );
+    }
+
+    public function testReusesValidExampleData(): void
+    {
+        $api = Api::create()
+            ->addOperation(
+                Operation::create('updateTest', '/test/{id}', 'PUT')
+                    ->addPathParameter(
+                        Parameter::create('id')->setSchema(
+                            new Schema([
+                                'type' => 'integer',
+                                'minimum' => 1,
+                                'maximum' => 1,
+                            ])
+                        )
+                    )
+                    ->addQueryParameter(
+                        Parameter::create('lang')->setSchema(
+                            new Schema([
+                                'type' => 'string',
+                            ])
+                        )
+                    )
+                    ->addRequestBody(
+                        Body::create(
+                            new Schema([
+                                'type' => 'object',
+                                'required' => ['name'],
+                                'properties' => [
+                                    'name' => [
+                                        'type' => 'string',
+                                    ],
+                                ],
+                            ]),
+                        )
+                    )
+                    ->addResponse(DefinitionResponse::create(200))
+                    ->addResponse(
+                        DefinitionResponse::create(404)
+                            ->setDescription('description test')
+                    )
+                    ->addExample(
+                        OperationExample::create('200')
+                            ->setQueryParameter('lang', 'en')
+                            ->setBody(
+                                BodyExample::create([
+                                    'name' => 'John Doe',
+                                ])
+                            )
+                            ->setResponse(ResponseExample::create('200'))
+                    )
+            );
+
+        $expected = [
+            new TestCase(
+                Error404Preparator::getName() . ' - updateTest - RandomPath',
+                OperationExample::create('test')
+                    ->setPath('/test/{id}')
+                    ->setMethod('PUT')
+                    ->setPathParameter('id', '1')
+                    ->setQueryParameter('lang', 'en')
+                    ->setBodyContent([
+                        'name' => 'John Doe',
+                    ])
+                    ->setResponse(ResponseExample::create('404', 'description test')),
+            ),
+        ];
+
+        $preparator = new Error404Preparator();
+
+        Assert::objectsEqual(
+            $expected,
+            $preparator->doPrepare($api->getOperations()),
+            ['parent']
         );
     }
 


### PR DESCRIPTION
Reuse the operation's valid example so the request body, query parameters and headers stay schema-compliant. If we let everything be randomized (setForceRandom), the faker-generated payload often violates the OpenAPI schema and the API answers 400 instead of 404, making these tests flaky.