### PR TITLE
Fix flaky generated 404 examples

### DIFF
--- a/src/Definition/Example/OperationExample.php
+++ b/src/Definition/Example/OperationExample.php
@@ -179,6 +179,15 @@ final class OperationExample
         return $this;
     }
 
+    public function withName(string $name): self
+    {
+        /** @var self $clone */
+        $clone = $this->deepCopy->copy($this);
+        $clone->setName($name);
+
+        return $clone;
+    }
+
     /**
      * @return array<string, int|string>
      */

--- a/src/Definition/Loader/OpenApiDefinitionLoader.php
+++ b/src/Definition/Loader/OpenApiDefinitionLoader.php
@@ -235,7 +235,9 @@ final class OpenApiDefinitionLoader implements DefinitionLoader
             $request = Body::create(
                 $schema,
                 $type,
-            );
+            )
+                ->setRequired($requestBody->required ?? false)
+            ;
             $collection->add($request);
         }
 

--- a/src/Preparator/Error404Preparator.php
+++ b/src/Preparator/Error404Preparator.php
@@ -8,7 +8,6 @@ use APITester\Definition\Collection\Operations;
 use APITester\Definition\Example\OperationExample;
 use APITester\Definition\Example\ResponseExample;
 use APITester\Definition\Operation;
-use APITester\Definition\Parameter;
 use APITester\Definition\Response as DefinitionResponse;
 use APITester\Test\TestCase;
 
@@ -66,6 +65,8 @@ final class Error404Preparator extends TestCasesPreparator
                     ->setHeaders($this->config->response->headers ?? [])
                     ->setContent($this->config->response->body ?? $response->getDescription())
             ),
+            false,
+            [],
             false
         );
     }
@@ -81,37 +82,5 @@ final class Error404Preparator extends TestCasesPreparator
             ->setForceRandom(false)
             ->setPathParameters($operation->getPathParameters()->getRandomExamples())
         ;
-    }
-
-    private function completeConfiguredRequestParameters(OperationExample $example): void
-    {
-        $example
-            ->setAuthenticationHeaders($this->tokens)
-            ->setHeaders($this->config->headers)
-        ;
-    }
-
-    private function getMissingRequiredExampleReason(Operation $operation, OperationExample $example): ?string
-    {
-        foreach ($operation->getRequestBodies() as $body) {
-            if ($body->isRequired() && $example->getBody() === null) {
-                return 'required request body has no example';
-            }
-        }
-
-        foreach (
-            [
-                Parameter::TYPE_QUERY => $operation->getQueryParameters(),
-                Parameter::TYPE_HEADER => $operation->getHeaders(),
-            ] as $in => $parameters
-        ) {
-            foreach ($parameters->where('required', true) as $parameter) {
-                if (!$example->hasParameter($parameter->getName(), $in)) {
-                    return "required {$in} parameter {$parameter->getName()} has no example";
-                }
-            }
-        }
-
-        return null;
     }
 }

--- a/src/Preparator/Error404Preparator.php
+++ b/src/Preparator/Error404Preparator.php
@@ -7,6 +7,8 @@ namespace APITester\Preparator;
 use APITester\Definition\Collection\Operations;
 use APITester\Definition\Example\OperationExample;
 use APITester\Definition\Example\ResponseExample;
+use APITester\Definition\Operation;
+use APITester\Definition\Parameter;
 use APITester\Definition\Response as DefinitionResponse;
 use APITester\Test\TestCase;
 
@@ -36,36 +38,80 @@ final class Error404Preparator extends TestCasesPreparator
      */
     private function prepareTestCase(DefinitionResponse $response): array
     {
+        $testCase = $this->buildError404TestCase($response);
+
+        return $testCase === null ? [] : [$testCase];
+    }
+
+    private function buildError404TestCase(DefinitionResponse $response): ?TestCase
+    {
         $operation = $response->getParent();
+        $example = $this->buildMissingResourceExample($operation);
+        $this->completeConfiguredRequestParameters($example);
 
-        $testcases = [];
+        $missingExampleReason = $this->getMissingRequiredExampleReason($operation, $example);
 
-        if ($operation->getRequestBodies()->count() === 0) {
-            $testcases[] = $this->buildTestCase(
-                OperationExample::create('RandomPath', $operation)
-                    ->setForceRandom()
-                    ->setResponse(
-                        ResponseExample::create()
-                            ->setStatusCode($this->config->response->getStatusCode() ?? '404')
-                            ->setHeaders($this->config->response->headers ?? [])
-                            ->setContent($this->config->response->body ?? $response->getDescription())
-                    )
+        if ($missingExampleReason !== null) {
+            $this->logger->warning(
+                "Skipping 404 test for operation {$operation->getId()}: {$missingExampleReason}."
             );
+
+            return null;
         }
 
-        foreach ($operation->getRequestBodies() as $ignored) {
-            $testcases[] = $this->buildTestCase(
-                OperationExample::create('RandomPath', $operation)
-                    ->setForceRandom()
-                    ->setResponse(
-                        ResponseExample::create()
-                            ->setStatusCode($this->config->response->getStatusCode() ?? '404')
-                            ->setHeaders($this->config->response->headers ?? [])
-                            ->setContent($this->config->response->body ?? $response->getDescription())
-                    )
-            );
+        return $this->buildTestCase(
+            $example->setResponse(
+                ResponseExample::create()
+                    ->setStatusCode($this->config->response->getStatusCode() ?? '404')
+                    ->setHeaders($this->config->response->headers ?? [])
+                    ->setContent($this->config->response->body ?? $response->getDescription())
+            ),
+            false
+        );
+    }
+
+    private function buildMissingResourceExample(Operation $operation): OperationExample
+    {
+        $example = $operation->getExamples()->count() === 0
+            ? OperationExample::create('RandomPath', $operation)
+            : $operation->getExample()->withName('RandomPath');
+
+        return $example
+            ->setAutoComplete(false)
+            ->setForceRandom(false)
+            ->setPathParameters($operation->getPathParameters()->getRandomExamples())
+        ;
+    }
+
+    private function completeConfiguredRequestParameters(OperationExample $example): void
+    {
+        $example
+            ->setAuthenticationHeaders($this->tokens)
+            ->setHeaders($this->config->headers)
+        ;
+    }
+
+    private function getMissingRequiredExampleReason(Operation $operation, OperationExample $example): ?string
+    {
+        foreach ($operation->getRequestBodies() as $body) {
+            if ($body->isRequired() && $example->getBody() === null) {
+                return 'required request body has no example';
+            }
         }
 
-        return $testcases;
+        foreach (
+            [
+                Parameter::TYPE_QUERY => $operation->getQueryParameters(),
+                Parameter::TYPE_HEADER => $operation->getHeaders(),
+            ] as $in => $parameters
+        ) {
+            foreach ($parameters->where('required', true) as $parameter) {
+                if (!$example->hasParameter($parameter->getName(), $in)) {
+                    return "required {$in} parameter {$parameter->getName()} has no example";
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Preparator/Error406Preparator.php
+++ b/src/Preparator/Error406Preparator.php
@@ -8,6 +8,7 @@ use APITester\Definition\Collection\Operations;
 use APITester\Definition\Example\OperationExample;
 use APITester\Definition\Example\ResponseExample;
 use APITester\Definition\Operation;
+use APITester\Definition\Parameter;
 use APITester\Preparator\Config\Error406PreparatorConfig;
 use APITester\Test\TestCase;
 
@@ -34,20 +35,52 @@ final class Error406Preparator extends TestCasesPreparator
                     $operation,
                     (string) $type
                 ))
+                ->filter()
         )->flatten();
     }
 
-    private function prepareTestCase(Operation $operation, string $type): TestCase
+    private function prepareTestCase(Operation $operation, string $type): ?TestCase
     {
+        $example = $this->buildInvalidMediaTypeExample($operation, $type);
+        $missingExampleReason = $this->getMissingRequiredExampleReason(
+            $operation,
+            $example,
+            [Parameter::TYPE_PATH, Parameter::TYPE_QUERY, Parameter::TYPE_HEADER]
+        );
+
+        if ($missingExampleReason !== null) {
+            $this->logger->warning(
+                "Skipping 406 test for operation {$operation->getId()}: {$missingExampleReason}."
+            );
+
+            return null;
+        }
+
         return $this->buildTestCase(
-            OperationExample::create('InvalidMediaType', $operation)
-                ->setHeaders([
-                    'Accept' => $type,
-                ])->setResponse(
+            $example
+                ->setResponse(
                     ResponseExample::create()
                         ->setStatusCode('406')
                         ->setContent($this->config->response->body ?? null)
-                ),
+            ),
+            false,
+            [],
+            false
         );
+    }
+
+    private function buildInvalidMediaTypeExample(Operation $operation, string $type): OperationExample
+    {
+        $example = $operation->getExamples()->count() === 0
+            ? OperationExample::create('InvalidMediaType', $operation)
+            : $operation->getExample()->withName('InvalidMediaType');
+
+        $example
+            ->setAutoComplete(false)
+            ->setForceRandom(false)
+        ;
+        $this->completeConfiguredRequestParameters($example);
+
+        return $example->setHeader('Accept', $type);
     }
 }

--- a/src/Preparator/TestCasesPreparator.php
+++ b/src/Preparator/TestCasesPreparator.php
@@ -8,6 +8,8 @@ use APITester\Definition\Body;
 use APITester\Definition\Collection\Operations;
 use APITester\Definition\Collection\Tokens;
 use APITester\Definition\Example\OperationExample;
+use APITester\Definition\Operation;
+use APITester\Definition\Parameter;
 use APITester\Definition\Token;
 use APITester\Preparator\Config\PreparatorConfig;
 use APITester\Preparator\Exception\InvalidPreparatorConfigException;
@@ -49,7 +51,8 @@ abstract class TestCasesPreparator
     final public function buildTestCase(
         OperationExample $example,
         bool $auth = true,
-        array $excludedFields = []
+        array $excludedFields = [],
+        bool $configureHeaders = true
     ): TestCase {
         $operation = $example->getParent();
 
@@ -57,7 +60,9 @@ abstract class TestCasesPreparator
             $example->setAuthenticationHeaders($this->tokens);
         }
 
-        $example->setHeaders($this->config->headers);
+        if ($configureHeaders) {
+            $example->setHeaders($this->config->headers);
+        }
 
         return new TestCase(
             static::getName()
@@ -182,6 +187,45 @@ abstract class TestCasesPreparator
                 true
             ))->generate()
         );
+    }
+
+    protected function completeConfiguredRequestParameters(OperationExample $example): void
+    {
+        $example
+            ->setAuthenticationHeaders($this->tokens)
+            ->setHeaders($this->config->headers)
+        ;
+    }
+
+    /**
+     * @param array<string> $parameterTypes
+     */
+    protected function getMissingRequiredExampleReason(
+        Operation $operation,
+        OperationExample $example,
+        array $parameterTypes = [Parameter::TYPE_QUERY, Parameter::TYPE_HEADER]
+    ): ?string {
+        foreach ($operation->getRequestBodies() as $body) {
+            if ($body->isRequired() && $example->getBody() === null) {
+                return 'required request body has no example';
+            }
+        }
+
+        $parametersByType = [
+            Parameter::TYPE_PATH => $operation->getPathParameters(),
+            Parameter::TYPE_QUERY => $operation->getQueryParameters(),
+            Parameter::TYPE_HEADER => $operation->getHeaders(),
+        ];
+
+        foreach ($parameterTypes as $in) {
+            foreach ($parametersByType[$in]->where('required', true) as $parameter) {
+                if (!$example->hasParameter($parameter->getName(), $in)) {
+                    return "required {$in} parameter {$parameter->getName()} has no example";
+                }
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Preparator/Error404PreparatorTest.php
+++ b/tests/Preparator/Error404PreparatorTest.php
@@ -15,6 +15,7 @@ use APITester\Preparator\Error404Preparator;
 use APITester\Test\TestCase;
 use APITester\Util\Assert;
 use cebe\openapi\spec\Schema;
+use Psr\Log\AbstractLogger;
 
 final class Error404PreparatorTest extends \PHPUnit\Framework\TestCase
 {
@@ -34,6 +35,99 @@ final class Error404PreparatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testKeepsDocumentedRequestBodyWhenRandomizingPath(): void
+    {
+        $preparator = new Error404Preparator();
+        $api = Api::create()
+            ->addOperation(
+                Operation::create('patchTest', '/test/{id}', 'PATCH')
+                    ->addPathParameter(self::integerIdPathParameter())
+                    ->addRequestBody(self::nameBody(required: true))
+                    ->addExample(
+                        OperationExample::create('default')
+                            ->setPathParameter('id', '1')
+                            ->setBodyContent(['name' => 'valid'])
+                    )
+                    ->addResponse(DefinitionResponse::create(200))
+                    ->addResponse(
+                        DefinitionResponse::create(404)
+                            ->setDescription('description test')
+                    )
+            )
+        ;
+
+        $testCases = iterator_to_array($preparator->doPrepare($api->getOperations()));
+
+        self::assertCount(1, $testCases);
+        $request = $testCases[0]->jsonSerialize()['request'];
+        self::assertSame('PATCH', $request->getMethod());
+        self::assertSame('/test/1', (string) $request->getUri());
+        self::assertSame('{"name":"valid"}', (string) $request->getBody());
+    }
+
+    public function testSkipsRequiredRequestBodyWhenNoExampleExists(): void
+    {
+        $preparator = new Error404Preparator();
+        $logger = new class() extends AbstractLogger {
+            /**
+             * @var array<string>
+             */
+            public array $messages = [];
+
+            /**
+             * @param array<string, mixed> $context
+             */
+            public function log($level, $message, array $context = []): void
+            {
+                $this->messages[] = (string) $message;
+            }
+        };
+        $preparator->setLogger($logger);
+        $api = Api::create()
+            ->addOperation(
+                Operation::create('patchTest', '/test/{id}', 'PATCH')
+                    ->addPathParameter(self::integerIdPathParameter())
+                    ->addRequestBody(self::nameBody(required: true))
+                    ->addResponse(DefinitionResponse::create(200))
+                    ->addResponse(DefinitionResponse::create(404))
+            )
+        ;
+
+        self::assertCount(0, iterator_to_array($preparator->doPrepare($api->getOperations())));
+        self::assertSame(
+            ['Skipping 404 test for operation patchTest: required request body has no example.'],
+            $logger->messages
+        );
+    }
+
+    private static function integerIdPathParameter(): Parameter
+    {
+        return Parameter::create('id')->setSchema(
+            new Schema([
+                'type' => 'integer',
+                'minimum' => 1,
+                'maximum' => 1,
+            ])
+        );
+    }
+
+    private static function nameBody(bool $required = false): Body
+    {
+        $body = Body::create(
+            new Schema([
+                'type' => 'object',
+                'required' => ['name'],
+                'properties' => [
+                    'name' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ])
+        );
+
+        return $required ? $body->setRequired() : $body;
+    }
+
     /**
      * @return iterable<array-key, array{Api, array<TestCase>}>
      */
@@ -43,15 +137,7 @@ final class Error404PreparatorTest extends \PHPUnit\Framework\TestCase
             Api::create()
                 ->addOperation(
                     Operation::create('getTest', '/test/{id}')
-                        ->addPathParameter(
-                            Parameter::create('id')->setSchema(
-                                new Schema([
-                                    'type' => 'integer',
-                                    'minimum' => 1,
-                                    'maximum' => 1,
-                                ])
-                            )
-                        )
+                        ->addPathParameter(self::integerIdPathParameter())
                         ->addResponse(DefinitionResponse::create(200))
                         ->addResponse(
                             DefinitionResponse::create(404)
@@ -73,19 +159,7 @@ final class Error404PreparatorTest extends \PHPUnit\Framework\TestCase
             Api::create()
                 ->addOperation(
                     Operation::create('postTest', '/test', 'POST')
-                        ->addRequestBody(
-                            Body::create(
-                                new Schema([
-                                    'type' => 'object',
-                                    'required' => ['name'],
-                                    'properties' => [
-                                        'name' => [
-                                            'type' => 'string',
-                                        ],
-                                    ],
-                                ]),
-                            )
-                        )
+                        ->addRequestBody(self::nameBody())
                         ->addResponse(DefinitionResponse::create(200))
                         ->addResponse(
                             DefinitionResponse::create(404)

--- a/tests/Preparator/Error406PreparatorTest.php
+++ b/tests/Preparator/Error406PreparatorTest.php
@@ -8,11 +8,13 @@ use APITester\Definition\Api;
 use APITester\Definition\Example\OperationExample;
 use APITester\Definition\Example\ResponseExample;
 use APITester\Definition\Operation;
+use APITester\Definition\Parameter;
 use APITester\Definition\Response as DefinitionResponse;
 use APITester\Preparator\Error406Preparator;
 use APITester\Test\TestCase;
 use APITester\Util\Assert;
 use cebe\openapi\spec\Schema;
+use Psr\Log\AbstractLogger;
 
 final class Error406PreparatorTest extends \PHPUnit\Framework\TestCase
 {
@@ -23,21 +25,107 @@ final class Error406PreparatorTest extends \PHPUnit\Framework\TestCase
      */
     public function test(Api $api, array $expected): void
     {
-        $preparator = new Error406Preparator();
-        $preparator->configure(
-            [
-                'mediaTypes' => [
-                    'application/vnd.koan',
-                    'application/javascript',
-                    'application/json',
-                ],
-            ]
-        );
+        $preparator = self::createPreparator([
+            'application/vnd.koan',
+            'application/javascript',
+            'application/json',
+        ]);
 
         Assert::objectsEqual(
             $expected,
             $preparator->doPrepare($api->getOperations()),
             ['parent']
+        );
+    }
+
+    public function testKeepsDocumentedRequestPathWhenChangingAccept(): void
+    {
+        $preparator = self::createPreparator(
+            ['application/xml', 'application/json'],
+            ['Accept' => 'application/json']
+        );
+        $api = Api::create()
+            ->addOperation(
+                Operation::create('courseIntroduction', '/courses/{courseId}/introduction')
+                    ->addPathParameter(self::courseIdPathParameter())
+                    ->addExample(
+                        OperationExample::create('default')
+                            ->setPathParameter('courseId', '1603881')
+                    )
+                    ->addResponse(
+                        DefinitionResponse::create(200)
+                            ->setMediaType('application/json')
+                    )
+            )
+        ;
+
+        $testCases = iterator_to_array($preparator->doPrepare($api->getOperations()));
+
+        self::assertCount(1, $testCases);
+        $request = $testCases[0]->jsonSerialize()['request'];
+        self::assertSame('/courses/1603881/introduction', (string) $request->getUri());
+        self::assertSame('application/xml', $request->getHeaderLine('Accept'));
+    }
+
+    public function testSkipsRequiredPathParameterWhenNoExampleExists(): void
+    {
+        $preparator = self::createPreparator(['application/xml', 'application/json']);
+        $logger = new class() extends AbstractLogger {
+            /**
+             * @var array<string>
+             */
+            public array $messages = [];
+
+            /**
+             * @param array<string, mixed> $context
+             */
+            public function log($level, $message, array $context = []): void
+            {
+                $this->messages[] = (string) $message;
+            }
+        };
+        $preparator->setLogger($logger);
+        $api = Api::create()
+            ->addOperation(
+                Operation::create('courseIntroduction', '/courses/{courseId}/introduction')
+                    ->addPathParameter(self::courseIdPathParameter())
+                    ->addResponse(
+                        DefinitionResponse::create(200)
+                            ->setMediaType('application/json')
+                    )
+            )
+        ;
+
+        self::assertCount(0, iterator_to_array($preparator->doPrepare($api->getOperations())));
+        self::assertSame(
+            ['Skipping 406 test for operation courseIntroduction: required path parameter courseId has no example.'],
+            $logger->messages
+        );
+    }
+
+    /**
+     * @param array<string>         $mediaTypes
+     * @param array<string, string> $headers
+     */
+    private static function createPreparator(array $mediaTypes, array $headers = []): Error406Preparator
+    {
+        $preparator = new Error406Preparator();
+        $preparator->configure([
+            'mediaTypes' => $mediaTypes,
+            'headers' => $headers,
+        ]);
+
+        return $preparator;
+    }
+
+    private static function courseIdPathParameter(): Parameter
+    {
+        return Parameter::create('courseId')->setSchema(
+            new Schema([
+                'type' => 'integer',
+                'minimum' => 1,
+                'maximum' => 2147483647,
+            ])
         );
     }
 


### PR DESCRIPTION
## Summary
- reuse documented request examples for generated 404 cases instead of fuzzing whole requests
- randomize only path parameters for missing-resource requests
- skip and warn when required request body/query/header examples are unavailable
- preserve OpenAPI requestBody.required during loading
- generate 406 cases from documented request examples, keep only Accept invalid, and skip with a warning when required path/query/header/body examples are unavailable

## Testing
- rtk git diff --check
- rtk git diff --check HEAD~1..HEAD
- Not run: PHP/PHPUnit; php and vendor/bin/phpunit are not available in this checkout. Earlier devenv attempts fail with `git-hooks or pre-commit-hooks input required` before PHP starts.